### PR TITLE
Removed num_samples=15 to take on default value.

### DIFF
--- a/sagemaker_processing/fairness_and_explainability/fairness_and_explainability_jsonlines_format.ipynb
+++ b/sagemaker_processing/fairness_and_explainability/fairness_and_explainability_jsonlines_format.ipynb
@@ -604,7 +604,7 @@
    "outputs": [],
    "source": [
     "shap_config = clarify.SHAPConfig(\n",
-    "    baseline=[baseline_sample], num_samples=15, agg_method=\"mean_abs\", save_local_shap_values=False\n",
+    "    baseline=[baseline_sample], agg_method=\"mean_abs\", save_local_shap_values=False\n",
     ")\n",
     "\n",
     "explainability_output_path = \"s3://{}/{}/clarify-explainability\".format(bucket, prefix)\n",


### PR DESCRIPTION
A recent comparison between Clarify and open SHAP highlighted a chance that the listed example with specify a num_samples value may lead to less optimal output when compared to the default behaviour in open SHAP.

*Issue #, if available:*

*Description of changes:*
Removed `num_samples=15` to take on default value.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-sagemaker-examples/blob/master/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-sagemaker-examples/blob/master/README.md)
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [x] I have linted my notebook(s) and code using `tox -e black-format,black-nb-format`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
